### PR TITLE
Merging work by NRG

### DIFF
--- a/pointcloud_processing/CMakeLists.txt
+++ b/pointcloud_processing/CMakeLists.txt
@@ -12,20 +12,15 @@ find_package(catkin REQUIRED COMPONENTS
   pcl_conversions
   pcl_ros
   roscpp
-  sensor_msgs
   darknet_ros_msgs
   message_filters
-  visualization_msgs
-  geometry_msgs
   pointcloud_processing_msgs
-  tf
-  tf2_geometry_msgs
-  sensor_msgs
+  visualization_msgs
+  tf2_sensor_msgs
   vision_msgs
 )
 
 ## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
 #find_package(PCL REQUIRED)
 
 
@@ -40,17 +35,11 @@ catkin_package(
   CATKIN_DEPENDS pcl_conversions
   pcl_ros
   roscpp
-  sensor_msgs
-  darknet_ros_msgs
   message_filters
-  visualization_msgs
-  geometry_msgs
   pointcloud_processing_msgs
-  tf
-  tf2_geometry_msgs
-  sensor_msgs
+  darknet_ros_msgs
+  tf2_sensor_msgs
   vision_msgs
-  tf2_geometry_msgs
 )
 
 ###########
@@ -60,18 +49,16 @@ catkin_package(
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(
-# include
   ${catkin_INCLUDE_DIRS}
 )
 
-add_executable(pcl_processing src/pcl_processing.cpp)
-add_executable(sep_processing src/sep_processing.cpp)
+add_executable(rgbd_processing src/pcl_processing.cpp)
+add_executable(rgb_plus_lidar_processing src/sep_processing.cpp)
 #add_executable(people_processing src/people_processing.cpp)
 
-target_link_libraries(pcl_processing ${catkin_LIBRARIES})
-target_link_libraries(sep_processing ${catkin_LIBRARIES})
+target_link_libraries(rgbd_processing ${catkin_LIBRARIES})
+target_link_libraries(rgb_plus_lidar_processing ${catkin_LIBRARIES})
 #target_link_libraries(people_processing ${catkin_LIBRARIES})
-
 
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)

--- a/pointcloud_processing/package.xml
+++ b/pointcloud_processing/package.xml
@@ -11,46 +11,20 @@
 
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>pcl_conversions</build_depend>
-  <build_depend>pcl_ros</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>libpcl-all-dev</build_depend>
-  <build_depend>darknet_ros_msgs</build_depend>
-  <build_depend>pointcloud_processing_msgs</build_depend>
-  <build_depend>message_filters</build_depend>
-  <build_depend>visualization_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>tf2_geometry_msgs</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>vision_msgs</build_depend>
-  <build_export_depend>pcl_conversions</build_export_depend>
-  <build_export_depend>pcl_ros</build_export_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>sensor_msgs</build_export_depend>
-  <build_export_depend>darknet_ros_msgs</build_export_depend>
-  <build_export_depend>message_filters</build_export_depend>
-  <build_export_depend>visualization_msgs</build_export_depend>
-  <build_export_depend>geometry_msgs</build_export_depend>
-  <build_export_depend>pointcloud_processing_msgs</build_export_depend>
-  <build_export_depend>tf</build_export_depend>
-  <build_export_depend>sensor_msgs</build_export_depend>
-  <build_export_depend>vision_msgs</build_export_depend>
-  <exec_depend>pcl_conversions</exec_depend>
-  <exec_depend>pcl_ros</exec_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>libpcl-all</exec_depend>
-  <exec_depend>darknet_ros_msgs</exec_depend>
-  <exec_depend>message_filters</exec_depend>
-  <exec_depend>visualization_msgs</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>pointcloud_processing_msgs</exec_depend>
-  <exec_depend>tf</exec_depend>   
-  <exec_depend>tf2_geometry_msgs</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>vision_msgs</exec_depend>
+  <depend>pcl_conversions</depend>
+  <depend>pcl_ros</depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>libpcl-all</depend>
+  <depend>darknet_ros_msgs</depend>
+  <depend>message_filters</depend>
+  <depend>visualization_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>pointcloud_processing_msgs</depend>
+  <depend>tf</depend>   
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_sensor_msgs</depend>
+  <depend>vision_msgs</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/pointcloud_processing/src/sep_processing.cpp
+++ b/pointcloud_processing/src/sep_processing.cpp
@@ -122,11 +122,11 @@ inline PixelCoords poseToPixel(const PointType &point,
 {
     PixelCoords result;
 
-    const PointType norm_point = normalizePoint(point);
+    // const PointType norm_point = normalizePoint(point);
 
-    result.x = camera_info.K[0]*norm_point.x + camera_info.K[2]*norm_point.z;
-    result.y = camera_info.K[4]*norm_point.y + camera_info.K[5]*norm_point.z;
-    result.z = norm_point.z;
+    result.x = camera_info.K[0]*point.x / point.z + camera_info.K[2];
+    result.y = camera_info.K[4]*point.y / point.z + camera_info.K[5];
+    result.z = point.z;// norm_point.z;
 
     return result;
 }

--- a/pointcloud_processing/src/sep_processing.cpp
+++ b/pointcloud_processing/src/sep_processing.cpp
@@ -89,26 +89,6 @@ void cameraInfoCb(const sensor_msgs::CameraInfoConstPtr msg)
 
 
 /**
- * @brief Normalize a point
- * @details The normalized results has a magnitude of 1.
- * @param input Point to be normalzied
- * @return The normalized point
- */
-inline PointType normalizePoint(PointType input)
-{    
-    const double denominator = std::sqrt(input.x * input.x +
-                                         input.y * input.y +
-                                         input.z * input.z);
-
-    input.x /= denominator;
-    input.y /= denominator;
-    input.z /= denominator;
-
-    return input;
-}
-
-
-/**
  * @brief Convert a cartesian point in the camera optical frame to (x,y) pixel coordinates.
  * @details Note: Make sure the point is in the optical camera frame, and not the link frame.
  *          We also provide the depth value of the pixel.
@@ -122,11 +102,9 @@ inline PixelCoords poseToPixel(const PointType &point,
 {
     PixelCoords result;
 
-    // const PointType norm_point = normalizePoint(point);
-
     result.x = camera_info.K[0]*point.x / point.z + camera_info.K[2];
     result.y = camera_info.K[4]*point.y / point.z + camera_info.K[5];
-    result.z = point.z;// norm_point.z;
+    result.z = point.z;
 
     return result;
 }

--- a/pointcloud_processing/src/sep_processing.cpp
+++ b/pointcloud_processing/src/sep_processing.cpp
@@ -376,6 +376,9 @@ void pointCloudCb(const sensor_msgs::PointCloud2ConstPtr& input_cloud)
     detected_objects.header.frame_id = input_cloud->header.frame_id;
     detected_objects.detections.reserve(current_boxes_.bounding_boxes.size());
 
+    // produce pixel-space coordinates
+    const std::vector<PixelCoords> pixel_coordinates_fov = convertCloudToPixelCoords(cloud_fov, camera_info_);
+
     /////////////////////////////////////////////////////////////
     for(const darknet_ros_msgs::BoundingBox &box : current_boxes_.bounding_boxes)
     {
@@ -384,7 +387,7 @@ void pointCloudCb(const sensor_msgs::PointCloud2ConstPtr& input_cloud)
         {            
             // ----------------------Extract points in the bounding box-----------
             const CloudPtr cloud_in_bbox = filterPointsInBox(cloud_fov,
-                                                             pixel_coordinates,
+                                                             pixel_coordinates_fov,
                                                              box.xmin,
                                                              box.xmax,
                                                              box.ymin,

--- a/target_detection/config/pose_estimation.yaml
+++ b/target_detection/config/pose_estimation.yaml
@@ -1,9 +1,3 @@
-DARKNET_TOPIC: darknet_ros/boundingbox
-PCL_TOPIC: points2
-TARGET_FRAME: walrus/odom
-TARGET_CLASS: chair
-VISUAL: true
-PCL_VISUAL: true
+debug_lidar_viz: true
 object_classes: 
   chair: '1'
-  microwave: '2'

--- a/target_detection/launch/pose_estimation.launch
+++ b/target_detection/launch/pose_estimation.launch
@@ -2,29 +2,22 @@
 <launch>
 
   <!-- ###########################  Pointcloud Processor ############################# -->
-    <arg name="darknet_topic" default="darknet_ros/boundingbox"/>
-    <arg name="retinanet_topic" default="retina_ros/boundingbox"/>
-    <arg name="pcl_topic" default="points2"/>
-    <arg name="fov_topic" default="fov_regions"/>
-    <arg name="target_frame" default="walrus/odom"/>
-    <arg name="target_class" default="chair"/>
-    <arg name="visual" default="true"/>
-    <arg name="pcl_visual" default="true"/>
-
-    <node pkg="pointcloud_processing" type="sep_processing" name="sep_processing_node" output="screen">
+    <node pkg="pointcloud_processing" type="rgb_plus_lidar_processing" name="sep_processing_node" output="screen" args="walrus/realsense_front_color_optical_frame">
       <rosparam command="load" file="$(find target_detection)/config/pose_estimation.yaml" />
-      <remap from="camera_info" to="/camera/color/camera_info"/>
+      <remap from="~camera_info" to="/camera/color/camera_info"/>
+      <remap from="~bounding_boxes" to="/darknet_ros/bounding_boxes"/>
+      <remap from="~pointcloud" to="/walrus/lidar_points"/>
     </node>
 
   <!-- ########################  Pointcloud transformer  ######################## -->
   <node pkg="nodelet" type="nodelet" name="test_nodelet"  args="manager" output="screen"/>
 
-  <node pkg="nodelet" type="nodelet" name="pointcloud_transformer" args="load transform_pointcloud/transformPointcloud test_nodelet" output="screen">
+  <!-- <node pkg="nodelet" type="nodelet" name="pointcloud_transformer" args="load transform_pointcloud/transformPointcloud test_nodelet" output="screen">
       <param name="to_frame" value="/walrus/realsense_front_color_optical_frame"/>
       <remap from="~input_pcl2" to="/walrus/lidar_points"/>
-  </node>
+  </node> -->
 
-  <node pkg="rviz_tools_py" type="fov_demo.py" name="fov_setter" />
+  <!-- <node pkg="rviz_tools_py" type="fov_demo.py" name="fov_setter" /> -->
 
   <!--<node pkg="nodelet" type="nodelet" name="pointcloud_transformer2" args="load transform_pointcloud/transformPointcloudTafr standalone_nodelet2" output="screen">-->
       <!--<param name="to_frame" value="laser"/>-->


### PR DESCRIPTION
This is the work done by NRG to execute the target detection capability on Walrus. We have made major changes to the package.

1. The names of the node targets have been changed to be more informative.
2. The `fov_demo` node and its FoV segmentation method are deprecated. A new method has been implemented within sep_processing.cpp
3. The `transform_pointcloud` package is deprecated. Pointcloud transformation to the camera optical frame is now done within sep_processing.cpp
4. sep_processing.cpp has been heavily revised. It contains new methods for FoV segmentation and bounding box segmentation of the pointcloud. The ROS API of this node is very different. Most significantly, the output is now in the form of a vision_msgs::Detection2DArray message.